### PR TITLE
Install the rest-client gem

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 include_recipe 'chef_handler'
 
 gem_package 'rest-client' do
-  gem_binary '/opt/chef/embedded/bin/gem'
+  gem_binary Chef::Util::PathHelper.join(Chef::Config.embedded_dir,'bin','gem')
   action :install
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: chef-handler-sumologic
 # Recipe:: default
 #
-# Copyright 2015, SumoLogic Inc. 
+# Copyright 2015, SumoLogic Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,13 +19,18 @@
 #
 include_recipe 'chef_handler'
 
+gem_package 'rest-client' do
+  gem_binary '/opt/chef/embedded/bin/gem'
+  action :install
+end
+
 cookbook_file "#{Chef::Config[:file_cache_path]}/chef-handler-sumologic.rb" do
-	source 'chef-handler-sumologic.rb'
-	mode 0600
+  source 'chef-handler-sumologic.rb'
+  mode 0600
 end.run_action(:create)
 
-chef_handler "Chef::Handler::SumoLogic" do
-	source "#{Chef::Config[:file_cache_path]}/chef-handler-sumologic.rb"
-	arguments [node[:sumologic][:endpoint]]
-	action :enable
+chef_handler 'Chef::Handler::SumoLogic' do
+  source "#{Chef::Config[:file_cache_path]}/chef-handler-sumologic.rb"
+  arguments [node[:sumologic][:endpoint]]
+  action :enable
 end


### PR DESCRIPTION
The chef-handler-sumologic.rb handler requires the rest-client gem, but the default chef ruby context doesn't include the rest-client gem, resulting in install failures for the handler.

This patch ensures the rest-client gem is installed to Chef's default ruby context before attempting to run the sumologic report handler.
